### PR TITLE
gui_location now checks if the location ends with .exe

### DIFF
--- a/ThirtyDollarGUI/ViewModels/MainWindowViewModel.cs
+++ b/ThirtyDollarGUI/ViewModels/MainWindowViewModel.cs
@@ -245,8 +245,11 @@ public class MainWindowViewModel : ViewModelBase
             downloader.Close();
 
             string? visualizer_filename = null;
-            var gui_location = Process.GetCurrentProcess().MainModule?.FileName.Replace("ThirtyDollarGUI", "");
-            
+            var gui_location = Process.GetCurrentProcess().MainModule?.FileName;
+            if (gui_location.Contains("ThirtyDollarGUI.exe")) gui_location = gui_location.Replace("ThirtyDollarGUI.exe", "");
+            else gui_location = gui_location.Replace("ThirtyDollarGUI", "");
+
+
             if (File.Exists($"{gui_location}/ThirtyDollarVisualizer")) visualizer_filename = $"{gui_location}/ThirtyDollarVisualizer";
             if (File.Exists($"{gui_location}/ThirtyDollarVisualizer.exe")) visualizer_filename = $"{gui_location}/ThirtyDollarVisualizer.exe";
 


### PR DESCRIPTION
On windows you can't open the visualizer throug the gui because it doesn't remove the ".exe" from the app location, this fixes it on windows